### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ keywords = ["ai", "ml"]
 
 [dependencies]
 nalgebra = "^0.32.4"
-image = "^0.24.9"
+image = { version = "^0.25.1", default-features = false }


### PR DESCRIPTION
Update dependencies and disable the default features of `image` to avoid pulling in all image parsers.